### PR TITLE
Made the join message display the player nickname

### DIFF
--- a/src/com/spiderrobotman/Gamemode4Engine/listeners/PlayerListener.java
+++ b/src/com/spiderrobotman/Gamemode4Engine/listeners/PlayerListener.java
@@ -58,7 +58,9 @@ public class PlayerListener implements Listener {
         String nick = Gamemode4Engine.nicks.get().getString(e.getPlayer().getUniqueId().toString());
         if (nick != null) {
             if (!nick.equalsIgnoreCase(e.getPlayer().getName())) {
-                e.getPlayer().setPlayerListName(Gamemode4Engine.config.get().getString("nickname_prefix").replace("&", "§") + ChatColor.RESET + nick.replace("&", "§"));
+                String displayNick = Gamemode4Engine.config.get().getString("nickname_prefix").replace("&", "§") + ChatColor.RESET + nick.replace("&", "§");
+                e.getPlayer().setPlayerListName(displayNick);
+                e.setJoinMessage(displayNick + " joined the game");
             } else {
                 e.getPlayer().setDisplayName(e.getPlayer().getName());
             }


### PR DESCRIPTION
I'm not sure whether the fact that the player nickname didn't show on join was intended. I've submitted a PR just in case you want to consider merging this. In my opinion this should be implemented as players would probably prefer their nickname to be shown on join.
